### PR TITLE
Numeric version comparison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ publishing {
 }
 
 bintray {
-    user = 'sarhanm'
+    user = 'steveperrin'
     key = System.env.BINTRAYTOKEN
     publications = ['mavenJava']
     dryRun = false

--- a/src/main/groovy/com/sarhanm/resolver/Version.groovy
+++ b/src/main/groovy/com/sarhanm/resolver/Version.groovy
@@ -51,9 +51,24 @@ class Version implements  Comparable<Version>{
 
     def int compareTo(Version other)
     {
-        major <=> other.major ?: minor <=> other.minor ?: point <=> other.point ?: hotfix <=> other.hotfix ?: branch <=> other.branch
+        // Compare major, minor, point, hotfix as integers;
+        // compare branch alphabetically; ignore commit hash
+        getIntVersionNum(major) <=> getIntVersionNum(other.major) ?:
+        getIntVersionNum(minor) <=> getIntVersionNum(other.minor) ?:
+        getIntVersionNum(point) <=> getIntVersionNum(other.point) ?:
+        getIntVersionNum(hotfix) <=> getIntVersionNum(other.hotfix) ?:
+        branch <=> other.branch
     }
 
+    def int getIntVersionNum( String ver )
+    {
+        if ( ver == null || ver == '' || ver == 'n' )
+        {
+            return -1
+        }
+
+        Integer.parseInt(ver)
+    }
 
     def boolean equals(Object obj) {
         this.compareTo(obj) == 0

--- a/src/main/groovy/com/sarhanm/versioner/GitData.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/GitData.groovy
@@ -1,11 +1,15 @@
 package com.sarhanm.versioner
 
 /**
+ * Git version data returned from the Versioner plugin for use in the build script.
  *
  * @author mohammad sarhan
  */
 class GitData {
-
-    def branch;
-    def commit;
+    def major;      // Major version number (n.0.0)
+    def minor;      // Minor version number (0.n.0)
+    def point;      // Point version number (0.0.n)
+    def hotfix;     // Optional hotfix version number (0.0.0.n)
+    def branch;     // Git branch name ("master")
+    def commit;     // Git short commit hash ("5f817fb142")
 }

--- a/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
@@ -66,11 +66,12 @@ class VersionerPlugin implements Plugin<Project>{
 
         //Adding git data so it can be used in the build script
         GitData data = project.extensions.create("gitdata",GitData)
+        data.major = versioner.getMajorMinor()
+        data.minor = versioner.getMajorMinor()
+        data.point = versioner.getVersionPoint()
+        data.hotfix = versioner.getHotfixNumber()
         data.branch = versioner.branch
         data.commit = versioner.commitHash
-
-        //TODO: Add other pieces of git metadata that might be needed
-
     }
 }
 

--- a/src/test/groovy/com/sarhanm/resolver/VersionCompareTest.groovy
+++ b/src/test/groovy/com/sarhanm/resolver/VersionCompareTest.groovy
@@ -24,6 +24,29 @@ class VersionCompareTest {
         assert v('1.3.n.n.master.abc') <  v('1.3.0.0.master.abc')
         assert v('1.3.n.master.abc') <  v('1.3.0.0.master.abc')
         assert v('1.3.2.master.abc') <  v('1.3.2.1.master.abc')
+
+        // Verify major version numbers are compared numerically
+        assert v('1.2.3.master.abc') <  v('5.2.3.master.abc')
+        assert v('10.2.3.master.abc') > v('5.2.3.master.abc')
+
+        // Verify minor version numbers are compared numerically
+        assert v('1.2.3.master.abc') <  v('1.5.3.master.abc')
+        assert v('1.10.3.master.abc') >  v('1.5.3.master.abc')
+
+        // Verify point version numbers are compared numerically
+        assert v('1.2.3.master.abc') <  v('1.2.5.master.abc')
+        assert v('1.2.10.master.abc') >  v('1.2.5.master.abc')
+
+        // Verify hotfix version numbers are compared numerically
+        assert v('1.2.3.4.master.abc') <  v('1.2.3.5.master.abc')
+        assert v('1.2.3.10.master.abc') >  v('1.2.3.5.master.abc')
+
+        // Verify branch names are compared alphabetically
+        assert v('1.2.3.beta1.abc') <  v('1.2.3.beta2.abc')
+        assert v('1.2.3.beta10.abc') <  v('1.2.3.beta2.abc')
+
+        // Verify commit hash is ignored
+        assert v('1.2.3.master.abc') ==  v('1.2.3.master.def')
     }
 
 }

--- a/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
+++ b/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
@@ -18,7 +18,7 @@ class VersionerTest {
         def gitMock = new MockFor(GitExecutor.class)
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv { params -> null }
+        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
         gitMock.demand.execute {params -> "origin/master"}
 
         gitMock.use {
@@ -125,7 +125,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1..20) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -143,8 +143,12 @@ class VersionerTest {
         gitMock.use {
             def versioner = new Versioner()
             versioner.envReader = envMock.proxyInstance()
-            assertEquals "hotfix-foobar" , versioner.getCleansedBranchName()
             assertEquals "2.3.3.4.hotfix-foobar.adbcdf", versioner.getVersion()
+            assertEquals "2.3", versioner.getMajorMinor()
+            assertEquals "3.4", versioner.getVersionPoint()
+            assertEquals 4, versioner.getHotfixNumber()
+            assertEquals "hotfix-foobar" , versioner.getCleansedBranchName()
+            assertEquals "adbcdf" , versioner.getCommitHash( )
         }
     }
 
@@ -321,8 +325,5 @@ class VersionerTest {
             assertEquals "2.3.4", versioner.getVersion()
         }
     }
-
-
-
 
 }

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Only publish the master branch
-if [ "$TRAVIS_REPO_SLUG" == "sarhanm/gradle-versioner" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+if [ "$TRAVIS_REPO_SLUG" == "steveperrin/gradle-versioner" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
     ./gradlew check bintrayUpload
 else
     ./gradlew check


### PR DESCRIPTION
Please review these changes for comparing version numbers numerically instead of alphabetically.  For example, version 1.0.1015 should be considered newer than 1.0.975 when using version ranges.

Also, added support for getting major, minor, point, and hotfix version numbers from the Versioner.  This is useful if you want to use only part of the version number in a file or artifact name.