### PR TITLE
Fixed problems with GitData major, minor, and point.  

### DIFF
--- a/src/main/groovy/com/sarhanm/versioner/GitData.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/GitData.groovy
@@ -6,10 +6,10 @@ package com.sarhanm.versioner
  * @author mohammad sarhan
  */
 class GitData {
-    def major;      // Major version number (n.0.0)
-    def minor;      // Minor version number (0.n.0)
-    def point;      // Point version number (0.0.n)
-    def hotfix;     // Optional hotfix version number (0.0.0.n)
-    def branch;     // Git branch name ("master")
-    def commit;     // Git short commit hash ("5f817fb142")
+    int major;      // Major version number (n.0.0)
+    int minor;      // Minor version number (0.n.0)
+    int point;      // Point version number (0.0.n)
+    int hotfix;     // Optional hotfix version number (0.0.0.n)
+    String branch;     // Git branch name ("master")
+    String commit;     // Git short commit hash ("5f817fb142")
 }

--- a/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
@@ -34,7 +34,10 @@ class Versioner
         this.options = versionerOptions
     }
 
-    def getHotfixNumber()
+    /**
+     * @return Hotfix version number as integer
+     */
+    public int getHotfixNumber()
     {
         def branchName = getBranchNameRaw()
         def commitList = executeGit("log --oneline $branchName...$options.commonHotfixBranch")
@@ -42,7 +45,11 @@ class Versioner
         return commitList ? commitList.split('\n').length : 0
     }
 
-    def getVersionPoint()
+    /**
+     * @return Point version number as String.  May contain both point
+     * and hotfix numbers for a hotfix branch (such as "5.2")
+     */
+    public String getVersionPoint()
     {
         if(isHotfix())
         {
@@ -66,7 +73,10 @@ class Versioner
         }
     }
 
-    def getMajorMinor()
+    /**
+     * @return Major and minor version numbers as String (such as "3.4")
+     */
+    public String getMajorMinor()
     {
         //We only want certain branches to have solid versions
         if(!useSolidMajorMinorVersion())
@@ -80,13 +90,42 @@ class Versioner
         return output.substring(1).trim()
     }
 
+    /**
+     * @return Major version number as integer
+     */
+    public int getMajorNumber()
+    {
+        def majorMinorSplit = getMajorMinor().split('\\.')
+        return Integer.parseInt( majorMinorSplit[0] )
+    }
+
+    /**
+     * @return Minor version number as integer
+     */
+    public int getMinorNumber()
+    {
+        def majorMinorSplit = getMajorMinor().split('\\.')
+        return Integer.parseInt( majorMinorSplit[1] )
+    }
+
+    /**
+     * @return Point version number as integer
+     */
+    public int getPointNumber()
+    {
+        def pointSplit = getVersionPoint().split('\\.')
+        return Integer.parseInt( pointSplit[0] )
+    }
+
+    /**
+     * @return Branch name without slashes or dots
+     */
     def String getCleansedBranchName()
     {
         return branch.replaceAll('/', '-').replaceAll('\\.','-')
     }
 
     /**
-     *
      * @return Branch name without the remote and/or origin prefix
      */
     def String getBranch()

--- a/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
@@ -66,9 +66,9 @@ class VersionerPlugin implements Plugin<Project>{
 
         //Adding git data so it can be used in the build script
         GitData data = project.extensions.create("gitdata",GitData)
-        data.major = versioner.getMajorMinor()
-        data.minor = versioner.getMajorMinor()
-        data.point = versioner.getVersionPoint()
+        data.major = versioner.getMajorNumber()
+        data.minor = versioner.getMinorNumber()
+        data.point = versioner.getPointNumber()
         data.hotfix = versioner.getHotfixNumber()
         data.branch = versioner.branch
         data.commit = versioner.commitHash

--- a/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
+++ b/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
@@ -146,9 +146,13 @@ class VersionerTest {
             assertEquals "2.3.3.4.hotfix-foobar.adbcdf", versioner.getVersion()
             assertEquals "2.3", versioner.getMajorMinor()
             assertEquals "3.4", versioner.getVersionPoint()
-            assertEquals 4, versioner.getHotfixNumber()
             assertEquals "hotfix-foobar" , versioner.getCleansedBranchName()
-            assertEquals "adbcdf" , versioner.getCommitHash( )
+            assertEquals "adbcdf" , versioner.getCommitHash()
+
+            assertEquals 2, versioner.getMajorNumber()
+            assertEquals 3, versioner.getMinorNumber()
+            assertEquals 3, versioner.getPointNumber()
+            assertEquals 4, versioner.getHotfixNumber()
         }
     }
 

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# Only publish the master branch
-if [ "$TRAVIS_REPO_SLUG" == "steveperrin/gradle-versioner" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
-    ./gradlew check bintrayUpload
+# Only publish the master branch that are NOT pull requests.
+if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    ./gradlew check bintrayUpload  publishPlugins
 else
     ./gradlew check
 fi


### PR DESCRIPTION
For example, 'major' contained both the major and minor version numbers.  Added Versioner methods to get major/minor/point versions as separate integers, similar to existing getHotfixNumber().  Changed GitData members to have explicit data types because they are part of the public interface.