### PR TITLE
For solid branch versions, use the # of commits since the latest version...

### DIFF
--- a/doc/versioner.md
+++ b/doc/versioner.md
@@ -33,11 +33,11 @@ The version scheme:
 
 #### For branch names master, release/.* and hotfix/.*
 
-    {major}.{minor}.{#-of-commits}.{hotfix-number}.{branch-name}.{short-commit-hash}
+    {major}.{minor}.{#-of-commits-from-tag}.{hotfix-number}.{branch-name}.{short-commit-hash}
  
 #### All other branches
 
-    0.0.{#-of-commits}.{hotfix-number}.{branch-name}.{short-commit-hash}
+    0.0.{#-of-commits-from-beginning-of-time}.{hotfix-number}.{branch-name}.{short-commit-hash}
 
 NOTE: in this case, we namespace out the version string and prepend with 0.0. More on this and how to configure it below. 
 
@@ -57,16 +57,20 @@ Example tags:
     v1.0
     v2.3
 
-This value will be used only for branch names "master", "hotfix/.*" and "release/.*"
+This value will be used only for branch names "master", "hotfix/.*" and "release/.*". 
 
 All other branches get a major.minor of '0.0'. This helps keep the version scheme uploaded to nexus clean (or any other artifact repository ).
  
 This can be configured via [com.sarhanm.versioner.VersionerOptions:solidBranchRegex](../src/main/groovy/com/sarhanm/versioner/VersionerOptions.groovy), so you could configure the plugin to always use the git tag for all branches. 
  
-### {#-of-commits}:
+### {#-of-commits-from-tag}:
  
-The is the number of commits since the inception of the git repo.
-  
+The is the number of commits from the most recent v{major}.{minor} tag.
+
+## {#-of-commits-from-beginning-of-time}
+
+This is the number of commits since the inception of the git repo.
+
 ### {hotfix-number}:
 
 This is the number of commits in the current branch that do not yet exist in the master branch. This assumes that hotfix branches are forked from master. 
@@ -93,8 +97,16 @@ NOTE: The reason we use environment variables to determine the branch name is th
 
 This is the short commit hash. Super useful to look at an artifact and know how to get to it to start a hotfix or developmet.
 
-## NOTE:
-Travis CI has a default git depth of 50. This means that your {#-of-commits} will stay at 50 unless you change the depth of your clone to something higher.
+## Shallow Clones
+For any shallow clone of the repo:
+
+1. {#-of-commits-from-beginning-of-time} will be based on the depth of your clone. Therefore the value is always wrong in a shallow clone.
+
+1. {#-of-commits-from-tag} will only work if the clone is deep enough to retrieve the latest tag. Otherwise the {#-of-commits-from-beginning-of-time} is used   
+
+Travis CI has a default git depth of 50. Make sure to set your depth based on the above information
+
+Example .travis file
 
 ```
 git:

--- a/src/main/groovy/com/sarhanm/versioner/GitData.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/GitData.groovy
@@ -12,4 +12,5 @@ class GitData {
     def hotfix;     // Optional hotfix version number (0.0.0.n)
     def branch;     // Git branch name ("master")
     def commit;     // Git short commit hash ("5f817fb142")
+    def totalCommits; //Total number of commits.
 }

--- a/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
@@ -74,11 +74,7 @@ class Versioner
                 }
             }
 
-            //Number of commits since start of time.
-            String output = executeGit(CMD_POINT)
-
-            //Default to zero if we are not able to get the point version
-            return output == null ? "0" : output.trim()
+            return totalCommits
         }
     }
 
@@ -179,6 +175,17 @@ class Versioner
         return false
     }
 
+    /**
+     *
+     * @return total commits since the inception of the repo
+     */
+    def getTotalCommits()
+    {
+        String output = executeGit(CMD_POINT)
+
+        //Default to zero
+        return output == null ? "0" : output.trim()
+    }
 
     /******************/
     /**** Private *****/

--- a/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
@@ -13,6 +13,7 @@ class Versioner
     static final CMD_BRANCH = "rev-parse --abbrev-ref HEAD"
     static final CMD_MAJOR_MINOR = "describe --match v* --abbrev=0"
     static final CMD_POINT = "rev-list HEAD --count"
+    static final CMD_POINT_SOLID_BRANCH = "describe --long --match v*"
     static final CMD_COMMIT_HASH =  "rev-parse --short HEAD"
 
     private cache = [:]
@@ -58,6 +59,21 @@ class Versioner
             return point
         }
         else{
+
+            if( useSolidMajorMinorVersion() )
+            {
+                //The point number is the number of commits since the last v{major}.{minor} tag.
+                //If no tag has been set yet, we fallback to the number of commits from the beginning of time.
+                String output = executeGit(CMD_POINT_SOLID_BRANCH)
+
+                if(output)
+                {
+                    def parts = output.trim().split("-")
+                    if(parts.length > 1)
+                        return parts[1]
+                }
+            }
+
             //Number of commits since start of time.
             String output = executeGit(CMD_POINT)
 

--- a/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
+++ b/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
@@ -164,8 +164,8 @@ class VersionerTest {
         gitMock.demand.execute(4) { params ->
             if (params == Versioner.CMD_BRANCH) "hotfix/foobar"
             else if (params == Versioner.CMD_MAJOR_MINOR) "v3.9"
-            else if (params == Versioner.CMD_POINT) "5"
-            else if (params == Versioner.getCMD_COMMIT_HASH()) "adbcdff"
+            else if (params == Versioner.CMD_COMMIT_HASH) "adbcdff"
+            else if (params == Versioner.CMD_POINT_SOLID_BRANCH) "v3.9-5-gcd4c01a"
             else throw new Exception("Unaccounted for method call")
         }
 
@@ -214,7 +214,8 @@ class VersionerTest {
             if (params == Versioner.CMD_BRANCH) "master"
             else if (params == Versioner.CMD_MAJOR_MINOR) "v3.9"
             else if (params == Versioner.CMD_POINT) "1005"
-            else if (params == Versioner.getCMD_COMMIT_HASH()) "adbcdff"
+            else if (params == Versioner.CMD_COMMIT_HASH) "adbcdff"
+            else if (params == Versioner.CMD_POINT_SOLID_BRANCH) "v3.9-1005-gcd4c01a"
             else throw new Exception("Unaccounted for method call")
         }
 
@@ -288,8 +289,8 @@ class VersionerTest {
         gitMock.demand.execute(1..5) { params ->
             if (params == Versioner.CMD_BRANCH) "master"
             else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
-            else if (params == Versioner.CMD_POINT) "4"
-            else if (params == Versioner.getCMD_COMMIT_HASH()) "adbcdf"
+            else if (params == Versioner.CMD_COMMIT_HASH) "adbcdf"
+            else if (params == Versioner.CMD_POINT_SOLID_BRANCH) "v2.3-4-gcd4c01a"
             else throw new Exception("Unaccounted for method call")
         }
 
@@ -313,8 +314,8 @@ class VersionerTest {
         gitMock.demand.execute(1..5) { params ->
             if (params == Versioner.CMD_BRANCH) "master"
             else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
-            else if (params == Versioner.CMD_POINT) "4"
-            else if (params == Versioner.getCMD_COMMIT_HASH()) "adbcdf"
+            else if (params == Versioner.CMD_COMMIT_HASH) "adbcdf"
+            else if (params == Versioner.CMD_POINT_SOLID_BRANCH) "v2.3-4-gcd4c01a"
             else throw new Exception("Unaccounted for method call")
         }
 
@@ -326,4 +327,104 @@ class VersionerTest {
         }
     }
 
+    @Test
+    public void testNullPointDescribeTag()
+    {
+        def envMock = new MockFor(EnvReader.class)
+
+        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+
+        def gitMock = new MockFor(GitExecutor.class)
+
+        gitMock.demand.execute(1..5) { params ->
+            if (params == Versioner.CMD_BRANCH) "master"
+            else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
+            else if (params == Versioner.CMD_POINT) "4"
+            else if (params == Versioner.CMD_COMMIT_HASH) "adbcdf"
+            else if (params == Versioner.CMD_POINT_SOLID_BRANCH) null
+            else throw new Exception("Unaccounted for method call")
+        }
+
+        gitMock.use {
+            def versioner = new Versioner()
+            versioner.envReader = envMock.proxyInstance()
+            assertEquals "2.3.4.master.adbcdf", versioner.getVersion()
+        }
+    }
+
+
+    @Test
+    public void testIncompletePointDescribeTag()
+    {
+        def envMock = new MockFor(EnvReader.class)
+
+        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+
+        def gitMock = new MockFor(GitExecutor.class)
+
+        gitMock.demand.execute(1..5) { params ->
+            if (params == Versioner.CMD_BRANCH) "master"
+            else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
+            else if (params == Versioner.CMD_POINT) "4"
+            else if (params == Versioner.CMD_COMMIT_HASH) "adbcdf"
+            else if (params == Versioner.CMD_POINT_SOLID_BRANCH) "v2.3"
+            else throw new Exception("Unaccounted for method call")
+        }
+
+        gitMock.use {
+            def versioner = new Versioner()
+            versioner.envReader = envMock.proxyInstance()
+            assertEquals "2.3.4.master.adbcdf", versioner.getVersion()
+        }
+    }
+
+    @Test
+    public void testIncompletePointDescribeTag2()
+    {
+        def envMock = new MockFor(EnvReader.class)
+
+        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+
+        def gitMock = new MockFor(GitExecutor.class)
+
+        gitMock.demand.execute(1..5) { params ->
+            if (params == Versioner.CMD_BRANCH) "master"
+            else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
+            else if (params == Versioner.CMD_POINT) "4"
+            else if (params == Versioner.CMD_COMMIT_HASH) "adbcdf"
+            else if (params == Versioner.CMD_POINT_SOLID_BRANCH) "v2.3-"
+            else throw new Exception("Unaccounted for method call")
+        }
+
+        gitMock.use {
+            def versioner = new Versioner()
+            versioner.envReader = envMock.proxyInstance()
+            assertEquals "2.3.4.master.adbcdf", versioner.getVersion()
+        }
+    }
+
+    @Test
+    public void testEmptyPointDescribeTag()
+    {
+        def envMock = new MockFor(EnvReader.class)
+
+        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+
+        def gitMock = new MockFor(GitExecutor.class)
+
+        gitMock.demand.execute(1..5) { params ->
+            if (params == Versioner.CMD_BRANCH) "master"
+            else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
+            else if (params == Versioner.CMD_POINT) "4"
+            else if (params == Versioner.CMD_COMMIT_HASH) "adbcdf"
+            else if (params == Versioner.CMD_POINT_SOLID_BRANCH) ""
+            else throw new Exception("Unaccounted for method call")
+        }
+
+        gitMock.use {
+            def versioner = new Versioner()
+            versioner.envReader = envMock.proxyInstance()
+            assertEquals "2.3.4.master.adbcdf", versioner.getVersion()
+        }
+    }
 }

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Only publish the master branch
-if [ "$TRAVIS_BRANCH" == "master" ]; then
+# Only publish the master branch that are NOT pull requests.
+if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     ./gradlew check bintrayUpload
 else
     ./gradlew check


### PR DESCRIPTION
Resetting the point value after a v{major}.{minor} version tag is set

The gitData object will now also contain a "totalCommits" value that can be used for "build numbers". (e.g. android builds)

Here is an example of what would happen. I’ve left out the branch and commit hash. 

v: 2.1.2
v: 2.1.1
v: 2.1.0
tagged: v2.1
v: 2.0.2
v: 2.0.1
v: 2.0.0
tagged: v2.0
v: 1.3.2
v: 1.3.1
v: 1.3.0
tagged: v1.3
