### PR TITLE
Fix issue with GitExecutor deadlocking when git output is too large.

### DIFF
--- a/src/main/groovy/com/sarhanm/versioner/GitExecutor.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/GitExecutor.groovy
@@ -1,33 +1,43 @@
 package com.sarhanm.versioner
 
+import org.gradle.api.Project
+
 /**
- * Seperate class so we can mock and test
+ * Separate class so we can mock and test
  * @author mohammad sarhan
  */
 class GitExecutor
 {
-    def File rootDir
-    GitExecutor(def File rootDir) {
-        this.rootDir = rootDir
+    def Project project
+    GitExecutor(def Project project) {
+        this.project = project
     }
 
-/**
+    /**
      * Executes the git command
      * @param cmdArgs
-     * @return
+     * @return output from command execution
      */
     def execute(cmdArgs)
     {
         def cmd = "git " + cmdArgs
-        def proc = cmd.execute(null, rootDir)
 
-        proc.waitFor()
+        new ByteArrayOutputStream().withStream { output ->
+            new ByteArrayOutputStream().withStream { error ->
 
-        if( proc.exitValue() != 0 )
-            return null;
+                def result = project.exec {
+                    commandLine = cmd.split(' ') as List
+                    workingDir = project.projectDir
+                    ignoreExitValue = true
+                    standardOutput = output
+                    errorOutput = error
+                }
 
-        def output = proc.in.text
+                if ( result.exitValue == 0 )
+                    return output.toString()
 
-        return output
+                return null
+            }
+        }
     }
 }

--- a/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
@@ -1,5 +1,7 @@
 package com.sarhanm.versioner
 
+import org.gradle.api.Project
+
 /**
  * Generates a solid and snapshot version using information
  * derived from the git repository
@@ -28,9 +30,9 @@ class Versioner
         this.options = new VersionerOptions()
     }
 
-    public Versioner(versionerOptions, File rootDir)
+    public Versioner(versionerOptions, Project project)
     {
-        this.gitExecutor = new GitExecutor(rootDir)
+        this.gitExecutor = new GitExecutor(project)
         this.envReader = new EnvReader()
         this.options = versionerOptions
     }

--- a/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
@@ -18,10 +18,8 @@ class VersionerPlugin implements Plugin<Project>{
         if (project.extensions.findByType(VersionerOptions) == null)
             project.extensions.create("versioner", VersionerOptions)
 
-        def rootDir = project.projectDir
-
         def params = project.extensions.getByType(VersionerOptions)
-        def versioner = new Versioner(params, rootDir)
+        def versioner = new Versioner(params, project)
 
         if (!params.disabled) {
             logger.info "Initial project $project.name version: $project.version"


### PR DESCRIPTION
The simple Groovy String.execute() method can deadlock if the piped
stdout/stderr stream of a subprocess generates more data than can
be in the stream buffer at once. Project.exec() does not suffer from
this deficiency so we use that to execute the git commands.