### PR TITLE
Enhance Versioner to use delayed evaluation of project version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .classpath
+.groovy/
 .gradle/
 .project
 .settings/

--- a/src/main/groovy/com/sarhanm/versioner/GitData.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/GitData.groovy
@@ -6,11 +6,50 @@ package com.sarhanm.versioner
  * @author mohammad sarhan
  */
 class GitData {
-    int major;          // Major version number (n.0.0)
-    int minor;          // Minor version number (0.n.0)
-    int point;          // Point version number (0.0.n)
-    int hotfix;         // Optional hotfix version number (0.0.0.n)
-    String branch;      // Git branch name ("master")
-    String commit;      // Git short commit hash ("5f817fb142")
-    int totalCommits;   // Total number of commits.
+    private Versioner versioner
+
+    GitData(Versioner versioner) {
+        this.versioner = versioner
+    }
+
+    // The computed version, may be different from project version
+    // if Versioner is disabled.
+    String getVersion() {
+        versioner.getVersion()
+    }
+
+    // Major version number (n.0.0)
+    int getMajor() {
+        versioner.getMajorNumber()
+    }
+
+    // Minor version number (0.n.0)
+    int getMinor() {
+        versioner.getMinorNumber()
+    }
+
+    // Point version number (0.0.n)
+    int getPoint() {
+        versioner.getPointNumber()
+    }
+
+    // Optional hotfix version number (0.0.0.n)
+    int getHotfix() {
+        versioner.getHotfixNumber()
+    }
+
+    // Git branch name ("master")
+    String getBranch() {
+        versioner.branch
+    }
+
+    // Git short commit hash ("5f817fb142")
+    String getCommit() {
+        versioner.commitHash
+    }
+
+    // Total number of commits.
+    int getTotalCommits() {
+        Integer.parseInt(versioner.getTotalCommits())
+    }
 }

--- a/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
@@ -21,24 +21,10 @@ class VersionerPlugin implements Plugin<Project>{
         def params = project.extensions.getByType(VersionerOptions)
         def versioner = new Versioner(params, project)
 
-        if (!params.disabled) {
-            logger.info "Initial project $project.name version: $project.version"
-            project.version = versioner.getVersion()
-
-            //Trying to make this log line machine readable and findable in long/huge logs
-            logger.quiet "versioner:${project.name}=$project.version"
-        }
+        //Adding Versioner as the version delegate
+        project.version = versioner
 
         //Adding git data so it can be used in the build script
-        GitData data = project.extensions.create("gitdata", GitData)
-        data.major = versioner.getMajorNumber()
-        data.minor = versioner.getMinorNumber()
-        data.point = versioner.getPointNumber()
-        data.hotfix = versioner.getHotfixNumber()
-        data.branch = versioner.branch
-        data.commit = versioner.commitHash
-        data.totalCommits = Integer.parseInt(versioner.getTotalCommits())
+        project.extensions.create("gitdata", GitData, versioner)
     }
 }
-
-

--- a/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
+++ b/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
@@ -18,7 +18,7 @@ class VersionerTest {
         def gitMock = new MockFor(GitExecutor.class)
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
         gitMock.demand.execute {params -> "origin/master"}
 
         gitMock.use {
@@ -63,7 +63,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
         gitMock.demand.execute(1){ params -> "foobar"}
@@ -83,7 +83,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -125,7 +125,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..20) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -161,7 +161,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -186,7 +186,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -210,7 +210,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -231,11 +231,46 @@ class VersionerTest {
     }
 
     @Test
+    void testToStringVersion()
+    {
+        def envMock = new MockFor(EnvReader.class)
+
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
+
+        def gitMock = new MockFor(GitExecutor.class)
+
+        gitMock.demand.execute(4) { params ->
+            if (params == Versioner.CMD_BRANCH) "master"
+            else if (params == Versioner.CMD_MAJOR_MINOR) "v3.9"
+            else if (params == Versioner.CMD_POINT) "1005"
+            else if (params == Versioner.CMD_COMMIT_HASH) "adbcdff"
+            else if (params == Versioner.CMD_POINT_SOLID_BRANCH) "v3.9-1005-gcd4c01a"
+            else throw new Exception("Unaccounted for method call")
+        }
+
+        gitMock.use {
+            def versioner = new Versioner()
+            versioner.envReader = envMock.proxyInstance()
+            assertEquals "3.9.1005.master.adbcdff", versioner.toString()
+        }
+    }
+
+    @Test
+    void testToStringVersionWithDisabledVersioner()
+    {
+        def versioner = new Versioner()
+        // Test the disabled behavior, normally should return the
+        // initial project version but the test constructor uses 1.0
+        versioner.options.disabled = true
+        assertEquals "1.0", versioner.toString()
+    }
+
+    @Test
     void testSnapshotVersion()
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -260,7 +295,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -286,7 +321,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -311,7 +346,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -336,7 +371,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -362,7 +397,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -387,7 +422,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -412,7 +447,7 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
@@ -437,27 +472,33 @@ class VersionerTest {
     {
         def envMock = new MockFor(EnvReader.class)
 
-        envMock.demand.getBranchNameFromEnv(1..10) { params -> null }
+        envMock.demand.getBranchNameFromEnv(1) { params -> null }
 
         def gitMock = new MockFor(GitExecutor.class)
 
-        gitMock.demand.execute(1..5) { params ->
+        gitMock.demand.execute(1..6) { params ->
             if (params == Versioner.CMD_BRANCH) "master"
             else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
             else if (params == Versioner.CMD_POINT) "4"
             else if (params == Versioner.CMD_COMMIT_HASH) "adbcdf"
             else if (params == Versioner.CMD_POINT_SOLID_BRANCH) ""
+            else if (params.startsWith("log --oneline ")) "one\ntwo\nthree\nfour"
             else throw new Exception("Unaccounted for method call")
         }
 
         gitMock.use {
             def versioner = new Versioner()
             versioner.envReader = envMock.proxyInstance()
-            GitData gitData = new GitData()
-            gitData.major = versioner.getMajorNumber()
-            gitData.minor = versioner.getMinorNumber()
-            gitData.point = versioner.getPointNumber()
-            gitData.totalCommits = versioner.getTotalCommits()
+            GitData gitData = new GitData(versioner)
+
+            assertEquals gitData.version, versioner.getVersion()
+            assertEquals gitData.major, versioner.getMajorNumber()
+            assertEquals gitData.minor, versioner.getMinorNumber()
+            assertEquals gitData.point, versioner.getPointNumber()
+            assertEquals gitData.hotfix, versioner.getHotfixNumber()
+            assertEquals gitData.branch, versioner.branch
+            assertEquals gitData.commit, versioner.commitHash
+            assertEquals gitData.totalCommits, Integer.parseInt(versioner.getTotalCommits())
         }
     }
 


### PR DESCRIPTION
Using the Gradle project version as a delayed evaluation of
toString makes it possible to have Versioner process the options
without requiring preemptive creation of the verioner extension.

The GitData extension is also enabled as a lazy evaluation object
to ensure that we do not need to execute any logic until we have
to do it.

Additionally the @Memoized annotation reduces the lazy calls to
some internal methods to no more than once.