### PR TITLE
Feature/fix lazy init

### DIFF
--- a/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
@@ -30,23 +30,20 @@ class Versioner
 
     public Versioner()
     {
-        this.gitExecutor = new GitExecutor()
-        this.envReader = new EnvReader()
-        this.options = new VersionerOptions()
-        // for unit testing we mock these two
-        this.projectName = "testProject"
-        this.initialVersion = "1.0"
-        this.logger = null
+        this(new VersionerOptions(), null)
     }
 
-    public Versioner(versionerOptions, Project project)
+    public Versioner(VersionerOptions versionerOptions, Project project)
     {
         this.gitExecutor = new GitExecutor(project)
         this.envReader = new EnvReader()
         this.options = versionerOptions
-        this.projectName = project.name
-        this.initialVersion = project.version
-        this.logger = project.logger
+
+        this.logger = project?.logger
+
+        // for unit testing we mock these two
+        this.projectName = project ? project.name : 'testProject'
+        this.initialVersion = project ? project.version : "1.0"
     }
 
     @Memoized

--- a/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/VersionerPlugin.groovy
@@ -21,8 +21,7 @@ class VersionerPlugin implements Plugin<Project>{
         def params = project.extensions.getByType(VersionerOptions)
         def versioner = new Versioner(params, project)
 
-        //Adding Versioner as the version delegate
-        project.version = versioner
+        project.version = "${->versioner.toString()}"
 
         //Adding git data so it can be used in the build script
         project.extensions.create("gitdata", GitData, versioner)

--- a/src/test/groovy/com/sarhanm/versioner/VersionerBuildTest.groovy
+++ b/src/test/groovy/com/sarhanm/versioner/VersionerBuildTest.groovy
@@ -51,7 +51,6 @@ class VersionerBuildTest extends IntegrationSpec {
 
         when:
         def result = runTasksSuccessfully("build")
-        println result.standardOutput
         def buildVersion = getVersionFromOutput(result.standardOutput)
         def version = new Version(buildVersion)
 

--- a/src/test/groovy/com/sarhanm/versioner/VersionerBuildTest.groovy
+++ b/src/test/groovy/com/sarhanm/versioner/VersionerBuildTest.groovy
@@ -41,7 +41,9 @@ class VersionerBuildTest extends IntegrationSpec {
     }
 
     def 'test build with ommit branch metadata option'() {
-        buildFile << DEFAULT_BUILD + '''
+        buildFile << DEFAULT_GIT_DRIVEN_BUILD + '''
+        apply plugin: 'java'
+        apply plugin: 'com.sarhanm.versioner'
         versioner{
             omitBranchMetadata=true
         }
@@ -49,6 +51,7 @@ class VersionerBuildTest extends IntegrationSpec {
 
         when:
         def result = runTasksSuccessfully("build")
+        println result.standardOutput
         def buildVersion = getVersionFromOutput(result.standardOutput)
         def version = new Version(buildVersion)
 
@@ -64,7 +67,6 @@ class VersionerBuildTest extends IntegrationSpec {
 
         apply plugin: 'java'
         apply plugin: 'com.sarhanm.versioner'
-        println project.version
         '''.stripIndent()
 
         when:
@@ -90,7 +92,6 @@ class VersionerBuildTest extends IntegrationSpec {
 
         apply plugin: 'java'
         apply plugin: 'com.sarhanm.versioner'
-        println project.version
         '''.stripIndent()
 
         when:
@@ -119,7 +120,6 @@ class VersionerBuildTest extends IntegrationSpec {
 
         apply plugin: 'java'
         apply plugin: 'com.sarhanm.versioner'
-        println project.version
         '''.stripIndent()
 
         when:
@@ -147,7 +147,6 @@ class VersionerBuildTest extends IntegrationSpec {
 
         apply plugin: 'java'
         apply plugin: 'com.sarhanm.versioner'
-        println project.version
         '''.stripIndent()
 
         when:
@@ -175,7 +174,6 @@ class VersionerBuildTest extends IntegrationSpec {
 
         apply plugin: 'java'
         apply plugin: 'com.sarhanm.versioner'
-        println project.version
         '''.stripIndent()
 
         when:
@@ -203,7 +201,6 @@ class VersionerBuildTest extends IntegrationSpec {
 
         apply plugin: 'java'
         apply plugin: 'com.sarhanm.versioner'
-        println project.version
         '''.stripIndent()
 
         when:
@@ -219,6 +216,37 @@ class VersionerBuildTest extends IntegrationSpec {
         assert version.hotfix == '2'
         assert version.branch == 'hotfix-release'
     }
+
+    def 'test with production plugin'() {
+        buildFile << DEFAULT_GIT_DRIVEN_BUILD + """
+
+        apply plugin: 'java'
+        apply plugin: 'com.sarhanm.versioner'
+        apply plugin: 'maven-publish'
+        publishing{
+            publications {
+                mavenIosApp(MavenPublication) {
+                    from project.components.java
+                    version project.version
+                }
+            }
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("build")
+        def buildVersion = getVersionFromOutput(result.standardOutput)
+        def version = new Version(buildVersion)
+
+        then:
+        version.valid
+        assert version.major == '1'
+        assert version.minor == '0'
+        assert version.point == '1'
+        assert version.branch == 'master'
+
+    }
+
 
     private String getVersionFromOutput(String output)
     {


### PR DESCRIPTION
@Alex-Vol-SV made the initial stab.
Tracy Keeling (@icecrystal23 ) came up with the idea of making the version string lazy init which ensures that project.version is always a string. This resolves issues in a bunch of our plugins that fail to deal with project.version accordingly when its a Versioner object. 