### PR TITLE
Avoid modifying already resolved configurations.

### DIFF
--- a/src/main/groovy/com/sarhanm/resolver/VersionResolutionPlugin.groovy
+++ b/src/main/groovy/com/sarhanm/resolver/VersionResolutionPlugin.groovy
@@ -3,6 +3,7 @@ package com.sarhanm.resolver
 import com.sarhanm.versioner.VersionerOptions
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 
 /**
  *
@@ -33,11 +34,9 @@ class VersionResolutionPlugin implements Plugin<Project>{
 
             def resolver = new VersionResolver(project,params, file)
             project.configurations.all {
-
-                // We've already resolved the versionManifest,
-                // and modifying a resolved configuration will fail the build starting
-                // in gradle 3+
-                if(it.name != versionManifest.name)
+                // Avoid modifying already resolved configurations.
+                // This will fail the build in Gradle v3+.
+                if (state == Configuration.State.UNRESOLVED)
                     resolutionStrategy.eachDependency(resolver)
             }
 


### PR DESCRIPTION
Other plugins or even build scripts may use single
file configurations and eagerly resolve them during
configuration stage. This avoids the problem that
would break the builds in Gradle 3+. Developers
may need to be given notice that they are resolving
the configurations eagerly and suggest using the
afterEvaluate approach. The order of plugin action
execution may need to be considered for these cases.