### PR TITLE
Fixes #22 - Add resolver to all configurations outside the afterEvaluate closure

### DIFF
--- a/src/main/groovy/com/sarhanm/resolver/VersionResolverOptions.groovy
+++ b/src/main/groovy/com/sarhanm/resolver/VersionResolverOptions.groovy
@@ -6,12 +6,6 @@ package com.sarhanm.resolver
  */
 class VersionResolverOptions {
 
-    /**
-     * Path (file://, http://, and https:// are supported)
-     * to the full list of versions that should be used in your project.
-      */
-    def VersionManifestOption manifest = new VersionManifestOption()
-
     def boolean outputComputedManifest = false
 }
 

--- a/src/test/groovy/com/sarhanm/resolver/VersionResolveViaManifestTest.groovy
+++ b/src/test/groovy/com/sarhanm/resolver/VersionResolveViaManifestTest.groovy
@@ -122,10 +122,8 @@ class VersionResolveViaManifestTest {
 
     }
 
-    private VersionResolverOptions getOption(def url, def username = null, def password = null)
+    private VersionManifestOption getOption(def url, def username = null, def password = null)
     {
-        def options = new VersionResolverOptions()
-        options.manifest = [ url: url, username: username, password: password] as VersionManifestOption
-        options
+        [ url: url, username: username, password: password] as VersionManifestOption
     }
 }


### PR DESCRIPTION
Allows us to add our resolver at the earliest moment and  add our resolver as new configurations are added.