### PR TITLE
Fixing a bug where the commit hash is sometimes 7 digits long and…

### DIFF
--- a/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
@@ -17,7 +17,7 @@ class Versioner {
     static final CMD_MAJOR_MINOR = "describe --match v* --abbrev=0"
     static final CMD_POINT = "rev-list HEAD --count"
     static final CMD_POINT_SOLID_BRANCH = "describe --long --match v*"
-    static final CMD_COMMIT_HASH = "rev-parse --short HEAD"
+    static final CMD_COMMIT_HASH = "rev-parse --short=7 HEAD"
 
     private cache = [:]
     private GitExecutor gitExecutor


### PR DESCRIPTION
… sometimes 8 digits long when running git rev-parse —short.  Older versions of git return 7 digits by default, newer versions of git return 8 digits by default.  Updating to always return 7 to eliminate discrepancies when running on different machines.