### PR TITLE
Include "main" as a solid branch identifier

### DIFF
--- a/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
@@ -9,7 +9,7 @@ import groovy.transform.Memoized
  * derived from the git repository
  */
 class Versioner {
-    static final DEFAULT_SOLID_BRANCH_REGEX = "master|.*release.*|.*hotfix.*"
+    static final DEFAULT_SOLID_BRANCH_REGEX = "master|main|.*release.*|.*hotfix.*"
     static final DEFAULT_HOTFIX_COMMON_BRANCH = "master"
 
     //Git commands also used in unit tests

--- a/src/main/groovy/com/sarhanm/versioner/VersionerOptions.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/VersionerOptions.groovy
@@ -62,7 +62,16 @@ class VersionerOptions {
     /**
      * The branch name of the common hotfix branch. Its the name of the branh
      * that you fork from when you create a hotfix. Currently defaults to 'master'
+     *
+     * @deprecated use {@link #commonHotfixBranches} instead.
      */
+    @Deprecated
     def String commonHotfixBranch = Versioner.DEFAULT_HOTFIX_COMMON_BRANCH
+
+    /**
+     * The branch names of the common hotfix branches. Its the name of a branch
+     * that you fork from when you create a hotfix. Currently defaults to 'master' or 'main'
+     */
+    def String[] commonHotfixBranches = Versioner.DEFAULT_HOTFIX_COMMON_BRANCHES
 
 }

--- a/src/test/groovy/com/sarhanm/versioner/VersionerBuildTest.groovy
+++ b/src/test/groovy/com/sarhanm/versioner/VersionerBuildTest.groovy
@@ -12,6 +12,7 @@ import org.gradle.testkit.runner.GradleRunner
 class VersionerBuildTest extends IntegrationSpec {
 
     static VERSIONER_PATTERN = ~/versioner:[^=]+=(.*)/
+    static DEFAULT_BRANCH_NAME = 'master'
 
     static DEFAULT_BUILD = '''
             plugins{
@@ -20,12 +21,16 @@ class VersionerBuildTest extends IntegrationSpec {
             apply plugin: 'java'
         '''.stripIndent()
 
-    def setupGitRepo() {
+    def setupGitRepo(String defaultBranch = DEFAULT_BRANCH_NAME) {
         execute('git init .')
         execute('git add .')
         execute('git config user.email "test@test.com"')
         execute('git config user.name "tester"')
         execute('git commit -m"commit" ')
+
+        if (defaultBranch != DEFAULT_BRANCH_NAME) {
+            execute("git branch -m $DEFAULT_BRANCH_NAME $defaultBranch")
+        }
     }
 
     def 'test build without options'() {
@@ -139,7 +144,6 @@ class VersionerBuildTest extends IntegrationSpec {
         execute('git checkout -b hotfix/some-hotfix')
         execute('git commit -m"adding file in hotfix" --allow-empty')
         execute('git commit -m"adding file in hotfix" --allow-empty')
-
 
         when:
         def result = runSuccessfully("build")

--- a/src/test/groovy/com/sarhanm/versioner/VersionerBuildTest.groovy
+++ b/src/test/groovy/com/sarhanm/versioner/VersionerBuildTest.groovy
@@ -135,7 +135,6 @@ class VersionerBuildTest extends IntegrationSpec {
         assert version.branch == 'master'
     }
 
-
     def 'test hotfix build'() {
         buildFile << DEFAULT_BUILD
 
@@ -156,6 +155,28 @@ class VersionerBuildTest extends IntegrationSpec {
         assert version.minor == '0'
         assert version.point == '2'
         assert version.hotfix == '2'
+        assert version.branch == 'hotfix-some-hotfix'
+    }
+
+    def 'test hotfix build on main'() {
+        buildFile << DEFAULT_BUILD
+
+        setupGitRepo('main')
+        execute('git commit -m"adding commit in main" --allow-empty')
+        execute('git checkout -b hotfix/some-hotfix')
+        execute('git commit -m"adding file in hotfix" --allow-empty')
+
+        when:
+        def result = runSuccessfully("build")
+        def buildVersion = getVersionFromOutput(result.output)
+        def version = new Version(buildVersion)
+
+        then:
+        version.valid
+        assert version.major == '1'
+        assert version.minor == '0'
+        assert version.point == '2'
+        assert version.hotfix == '1'
         assert version.branch == 'hotfix-some-hotfix'
     }
 

--- a/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
+++ b/src/test/groovy/com/sarhanm/versioner/VersionerTest.groovy
@@ -125,9 +125,11 @@ class VersionerTest {
 
         def gitMock = new MockFor(GitExecutor.class)
 
-        gitMock.demand.execute(6) { params ->
+        gitMock.demand.execute(8) { params ->
             if (params == Versioner.CMD_BRANCH) "hotfix/foobar"
             else if (params.startsWith("log --oneline hotfix/foobar")) "one\ntwo\nthree\nfour"
+            else if (params == "rev-parse --quiet --verify main") null
+            else if (params == "rev-parse --quiet --verify master") "commit-hash-return"
             else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
             else if (params == Versioner.CMD_POINT) "4"
             else if (params == Versioner.getCMD_COMMIT_HASH()) "adbcdf"
@@ -160,9 +162,11 @@ class VersionerTest {
 
         def gitMock = new MockFor(GitExecutor.class)
 
-        gitMock.demand.execute(6) { params ->
+        gitMock.demand.execute(8) { params ->
             if (params == Versioner.CMD_BRANCH) "release/hotfix"
             else if (params.startsWith("log --oneline release/hotfix")) "one\ntwo\nthree\nfour"
+            else if (params == "rev-parse --quiet --verify main") null
+            else if (params == "rev-parse --quiet --verify master") "commit-hash-return"
             else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
             else if (params == Versioner.CMD_POINT) "4"
             else if (params == Versioner.getCMD_COMMIT_HASH()) "adbcdf"
@@ -510,13 +514,15 @@ class VersionerTest {
 
         def gitMock = new MockFor(GitExecutor.class)
 
-        gitMock.demand.execute(1..6) { params ->
+        gitMock.demand.execute(1..8) { params ->
             if (params == Versioner.CMD_BRANCH) "master"
             else if (params == Versioner.CMD_MAJOR_MINOR) "v2.3"
             else if (params == Versioner.CMD_POINT) "4"
             else if (params == Versioner.CMD_COMMIT_HASH) "adbcdf"
             else if (params == Versioner.CMD_POINT_SOLID_BRANCH) ""
             else if (params.startsWith("log --oneline ")) "one\ntwo\nthree\nfour"
+            else if (params == "rev-parse --quiet --verify main") null
+            else if (params == "rev-parse --quiet --verify master") "commit-hash-return"
             else throw new Exception("Unaccounted for method call")
         }
 


### PR DESCRIPTION
As a part of ZGs push to promote Equity and Belonging identifying "main" as a solid branch allows for generating versions appropriately when the updated terminology. 

To do:
- [x] Update `DEFAULT_SOLID_BRANCH_REGEX` to include `main` as a valid solid branch.
- [x] Update `hotfix` branch identification to match a list of options.
    - Deprecate old `VersionerOptions.commonHotfixBranch` setting.
    - Replace with new `VersionerOptions.commonHotfixBranches` setting which will attempt to match the first common `hotfix` branch from the supplied list.
    - Ensure backwards compatibility by adding `VersionerOptions.commonHotfixBranch` to `VersionerOptions.commonHotfixBranches` if it does not exist.
- [x] Fix existing tests, mostly adding in more mocking calls to `git`.
- [x] Extend integration tests in `VersionerBuildTest` to introduce new test which targets `main` as a `hotfix` branch.

PS. I'm definitely not a `groovy` dev so likely a fair few rookie mistakes, please be as brutal as possible to get to the desired standard!