### PR TITLE
Upgrade publish-plugin to latest to remedy security error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.jfrog.bintray' version "1.8.4"
     id 'com.sarhanm.versioner' version '2.4.0'
-    id 'com.gradle.plugin-publish' version '0.9.1'
+    id 'com.gradle.plugin-publish' version '0.12.0'
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.6.3'
 }


### PR DESCRIPTION
Hopefully fixes: https://travis-ci.org/github/sarhanm/gradle-versioner/builds/737159228#L1166

Not sure how to test this out given I'm guessing this needs permissions and only runs on `master`, I've taken a glance at the [changes for the plugin](https://plugins.gradle.org/plugin/com.gradle.plugin-publish) and nothing major jumps out but not sure as I'm not much of a Java/Groovy person!