### PR TITLE
Update solution for VersionRangeResolver gradle 6 compatibility to be backwards compatible

### DIFF
--- a/src/main/groovy/com/sarhanm/resolver/VersionRangeResolverForGradleVersionsLessThan6.groovy
+++ b/src/main/groovy/com/sarhanm/resolver/VersionRangeResolverForGradleVersionsLessThan6.groovy
@@ -7,22 +7,18 @@ import org.gradle.api.artifacts.ComponentMetadata
 import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.model.Mutate
 
-/**
- *
- * @author Mohammad Sarhan (mohammad@)
- */
-class VersionRangeResolver {
+class VersionRangeResolverForGradleVersionsLessThan6 {
+
 
     VersionResolverInternal resolver
 
-    VersionRangeResolver(VersionResolverInternal resolver) {
+    VersionRangeResolverForGradleVersionsLessThan6(VersionResolverInternal resolver) {
         this.resolver = resolver
     }
 
     @Mutate
-    void evaluateVersionRange(ComponentSelection selection) {
+    void evaluateVersionRange(ComponentSelection selection, ComponentMetadata metadata) {
 
-        ComponentMetadata metadata = selection.getMetadata()
         VersionRangeResolverHelper.evaluateVersionRange(selection, metadata, resolver)
     }
 }

--- a/src/main/groovy/com/sarhanm/resolver/VersionRangeResolverHelper.groovy
+++ b/src/main/groovy/com/sarhanm/resolver/VersionRangeResolverHelper.groovy
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2018 Zillow, Inc
+ */
+package com.sarhanm.resolver
+
+import org.gradle.api.artifacts.ComponentMetadata
+import org.gradle.api.artifacts.ComponentSelection
+
+/**
+ * Resolving version ranges is done by rejecting all versions that are not "in" range.
+ *
+ * @author Mohammad Sarhan (mohammad@)
+ */
+class VersionRangeResolverHelper {
+
+    static void evaluateVersionRange(ComponentSelection selection, ComponentMetadata metadata, VersionResolverInternal resolver) {
+
+        def verString = null
+        def group = metadata.id.group
+        def name = metadata.id.name
+
+        if (resolver.isExplicitlyVersioned(group, name)) {
+            verString = resolver.getExplicitVersionFromProject(group, name)
+        } else {
+            verString = resolver.resolveVersion(group, name, verString)
+        }
+
+        //If we can't get to a valid version, then we won't be able to restrict the version
+        if (!verString)
+            return
+
+        def verRange = new VersionRange(verString)
+
+        if (verRange.valid && !verRange.contains(selection.candidate.version))
+            selection.reject("Version $selection.candidate.version is not contained within $verString")
+    }
+}

--- a/src/test/groovy/com/sarhanm/resolver/VersionResolutionConfigurerTest.groovy
+++ b/src/test/groovy/com/sarhanm/resolver/VersionResolutionConfigurerTest.groovy
@@ -1,0 +1,43 @@
+package com.sarhanm.resolver
+
+import org.junit.BeforeClass
+import org.junit.Test
+import spock.lang.Specification
+
+import static org.junit.Assert.*
+
+class VersionResolutionConfigurerTest extends Specification{
+
+
+    def testGetMajorVersionFromGradleVersionString() {
+        when:
+        def v = VersionResolutionConfigurer.getMajorVersionFromGradleVersionString("6.7.1")
+        then:
+        6 == v
+
+        when:
+        v = VersionResolutionConfigurer.getMajorVersionFromGradleVersionString("12.7.1")
+        then:
+        12 == v
+
+        when:
+        v = VersionResolutionConfigurer.getMajorVersionFromGradleVersionString("1.7.1")
+        then:
+        1 == v
+
+        when:
+        v = VersionResolutionConfigurer.getMajorVersionFromGradleVersionString("4.0.0")
+        then:
+        4 == v
+
+        when:
+        v = VersionResolutionConfigurer.getMajorVersionFromGradleVersionString("3.5.0")
+        then:
+        3 == v
+
+        when:
+        v = VersionResolutionConfigurer.getMajorVersionFromGradleVersionString("2.1.1")
+        then:
+        2 == v
+    }
+}

--- a/src/test/groovy/com/sarhanm/resolver/VersionResolverViaGradle2.groovy
+++ b/src/test/groovy/com/sarhanm/resolver/VersionResolverViaGradle2.groovy
@@ -1,0 +1,13 @@
+package com.sarhanm.resolver
+
+/**
+ *
+ * @author Mohammad Sarhan
+ */
+class VersionResolverViaGradle2 extends  VersionResolverViaGradleVersionsTest {
+
+    @Override
+    def String getAlternateGradleVersion() {
+        return '2.14.1'
+    }
+}

--- a/src/test/groovy/com/sarhanm/resolver/VersionResolverViaGradle3.groovy
+++ b/src/test/groovy/com/sarhanm/resolver/VersionResolverViaGradle3.groovy
@@ -1,0 +1,13 @@
+package com.sarhanm.resolver
+
+/**
+ *
+ * @author Mohammad Sarhan
+ */
+class VersionResolverViaGradle3 extends  VersionResolverViaGradleVersionsTest {
+
+    @Override
+    def String getAlternateGradleVersion() {
+        return '3.1'
+    }
+}

--- a/src/test/groovy/com/sarhanm/resolver/VersionResolverViaGradle4.groovy
+++ b/src/test/groovy/com/sarhanm/resolver/VersionResolverViaGradle4.groovy
@@ -1,0 +1,13 @@
+package com.sarhanm.resolver
+
+/**
+ *
+ * @author Mohammad Sarhan
+ */
+class VersionResolverViaGradle4 extends  VersionResolverViaGradleVersionsTest {
+
+    @Override
+    def String getAlternateGradleVersion() {
+        return '4.4.1'
+    }
+}


### PR DESCRIPTION
Update solution for VersionRangeResolver gradle 6 compatibility to be backwards compatible

Also resurrected the test files for the older gradle versions


Motivation: with the prior backwards-incompatible approach, we ran into issues using `includeBuild` to include other local projects that were still using an older version of this plugin.