### PR TITLE
BUG: Fix count from last tag

### DIFF
--- a/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
+++ b/src/main/groovy/com/sarhanm/versioner/Versioner.groovy
@@ -18,7 +18,7 @@ class Versioner {
     static final CMD_BRANCH = "rev-parse --abbrev-ref HEAD"
     static final CMD_MAJOR_MINOR = "describe --match v* --abbrev=0 --tags"
     static final CMD_POINT = "rev-list HEAD --count"
-    static final CMD_POINT_SOLID_BRANCH = "describe --long --match v*"
+    static final CMD_POINT_SOLID_BRANCH = "describe --long --match v* --tags"
     static final CMD_COMMIT_HASH = "rev-parse --short=7 HEAD"
 
     private cache = [:]


### PR DESCRIPTION
v4.0.2 count a master branch # of commit count from start, not previous tag.
This fix a problem.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>