### PR TITLE
Updating gradle versioner to work with gradle 7.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,20 +22,31 @@ repositories {
     mavenCentral()
 }
 
+def String majorGradleVersionString = gradle.gradleVersion.substring(0, gradle.gradleVersion.indexOf('.'))
+def Integer majorGradleVersion = Integer.parseInt(majorGradleVersionString)
+def Integer majorGradleVersionRequiringGroovy3 = 7
+
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
+    implementation gradleApi()
+    implementation localGroovy()
 
+    implementation 'org.yaml:snakeyaml:1.28'
+    implementation 'io.github.http-builder-ng:http-builder-ng-apache:1.0.4'
 
-    compile 'org.yaml:snakeyaml:1.28'
-    compile 'io.github.http-builder-ng:http-builder-ng-apache:1.0.4'
+    testImplementation gradleTestKit()
 
-    testCompile gradleTestKit()
-    testCompile ('org.spockframework:spock-core:1.2-groovy-2.5'){
-        exclude module : 'groovy-all'
+    if (majorGradleVersion >= majorGradleVersionRequiringGroovy3) {
+        testImplementation('org.spockframework:spock-core:2.0-groovy-3.0') {
+            exclude module: 'groovy-all'
+        }
+    } else {
+        testImplementation ('org.spockframework:spock-core:1.2-groovy-2.5'){
+            exclude module: 'groovy-all'
+        }
     }
 
-    testCompile 'com.netflix.nebula:nebula-test:7.2.3'
+    testImplementation 'com.netflix.nebula:nebula-test:7.2.3'
+    testImplementation 'junit:junit:4.12'
 }
 
 jacocoTestReport {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/groovy/com/sarhanm/resolver/VersionResolutionConfigurerTest.groovy
+++ b/src/test/groovy/com/sarhanm/resolver/VersionResolutionConfigurerTest.groovy
@@ -11,7 +11,12 @@ class VersionResolutionConfigurerTest extends Specification{
 
     def testGetMajorVersionFromGradleVersionString() {
         when:
-        def v = VersionResolutionConfigurer.getMajorVersionFromGradleVersionString("6.7.1")
+        def v = VersionResolutionConfigurer.getMajorVersionFromGradleVersionString("7.1.1")
+        then:
+        7 == v
+
+        when:
+        v = VersionResolutionConfigurer.getMajorVersionFromGradleVersionString("6.7.1")
         then:
         6 == v
 


### PR DESCRIPTION
Fixed a handful of breaking issues:

- Updated 'compile' to 'implementation'
- Added explicit junit dependency, which is now needed
- Updated groovy dependency from 2.x to 3.x

Upgrade notes here: https://docs.gradle.org/current/userguide/upgrading_version_6.html
